### PR TITLE
Fix goto definition visibility

### DIFF
--- a/builtin/stringbuilder_buffer.mbt
+++ b/builtin/stringbuilder_buffer.mbt
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 ///|
-struct StringBuilder {
+pub struct StringBuilder {
   mut data : FixedArray[Byte]
   mut len : Int
 }

--- a/builtin/stringbuilder_concat.mbt
+++ b/builtin/stringbuilder_concat.mbt
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 ///|
-type StringBuilder Ref[String]
+pub type StringBuilder Ref[String]
 
 ///|
 /// Creates a new string builder with an optional initial capacity hint.

--- a/result/result.mbt
+++ b/result/result.mbt
@@ -13,6 +13,12 @@
 // limitations under the License.
 
 ///|
+pub enum Result[T, E] {
+  Ok(T),
+  Err(E),
+}
+
+///|
 /// Maps the value of a Result if it is `Ok` into another, otherwise returns the `Err` value unchanged.
 ///
 /// # Example


### PR DESCRIPTION
## Summary
- make StringBuilder struct public
- expose Result enum for better navigation

## Testing
- `git status --short`