### PR TITLE
fix(regex): runtime bounds checks for StateId packing and transition table growth

### DIFF
--- a/string/internal/regex_engine/state_id.mbt
+++ b/string/internal/regex_engine/state_id.mbt
@@ -19,18 +19,37 @@ priv struct StateId(Int64)
 let pending_state_id : StateId = -1
 
 ///|
+const MAX_STATE_INDEX : Int = 0b1111_1111_1111_1111_1110
+
+///|
+const MAX_SLOT_INDEX : Int = 0b111_1111_1111
+
+///|
+const MAX_NUM_SYMBOLS : Int = 0b111_1111_1110
+
+///|
+const MAX_TRANSITION_BASE : Int64 = 0x7fff_ffffL
+
+///|
 fn StateId::new(
   index~ : Int,
   slot~ : @automata.Slot,
   is_break~ : Bool,
   num_symbols~ : Int,
 ) -> StateId {
+  guard index >= 0 && index <= MAX_STATE_INDEX else { panic() }
+  guard slot.index >= 0 && slot.index <= MAX_SLOT_INDEX else { panic() }
+  guard num_symbols > 0 && num_symbols <= MAX_NUM_SYMBOLS else { panic() }
+  let transition_base64 = index.to_int64() * num_symbols.to_int64()
+  guard transition_base64 >= 0L && transition_base64 <= MAX_TRANSITION_BASE else {
+    panic()
+  }
+  let transition_base = transition_base64.to_int()
   debug_assert(() => {
-    index <= 0b1111_1111_1111_1111_1110 &&
-    slot.index <= 0b111_1111_1111 &&
-    num_symbols <= 0b111_1111_1110
+    index <= MAX_STATE_INDEX &&
+    slot.index <= MAX_SLOT_INDEX &&
+    num_symbols <= MAX_NUM_SYMBOLS
   })
-  let transition_base = index * num_symbols
   let encoded_index = if is_break { -2 - index } else { index }
   let id = StateId(
     (((encoded_index << 11) | slot.index).to_int64() << 32) |

--- a/string/internal/regex_engine/states.mbt
+++ b/string/internal/regex_engine/states.mbt
@@ -39,13 +39,24 @@ fn Regex::stablize_state(self : Regex, state : @automata.State) -> StateId {
     self.num_states += 1
     let num_symbols = self.num_symbols()
     if index >= self.states.length() {
-      let new_states_len = Int::max(self.states.length() * 2, 4)
+      let new_states_len = if self.states.length() < 2 {
+        4
+      } else {
+        let doubled = self.states.length().to_int64() * 2L
+        guard doubled <= 0x7fff_ffffL else { panic() }
+        doubled.to_int()
+      }
+      let new_transition_len64 = new_states_len.to_int64() * num_symbols.to_int64()
+      guard new_transition_len64 >= 0L && new_transition_len64 <= 0x7fff_ffffL else {
+        panic()
+      }
+      let new_transition_len = new_transition_len64.to_int()
 
       let new_states = FixedArray::make(new_states_len, @automata.st_dummy)
       self.states.blit_to(new_states, len=self.states.length())
 
       let new_transition_table = FixedArray::make(
-        new_states_len * num_symbols,
+        new_transition_len,
         pending_state_id,
       )
       self.transition_table.blit_to(


### PR DESCRIPTION
### Motivation
- The regex engine packed `index`, `slot`, and a `transition_base` into a 64-bit `StateId` and relied only on `debug_assert`, which allows overflow/truncation of `transition_base` in release builds and can lead to out-of-bounds `unsafe_get` on the transition table.
- The change ensures runtime validation of the bit-width limits and transition-table sizing to prevent overflow-driven OOB indexing for large user-supplied regexes.

### Description
- Added explicit encoding limits and runtime guards in `StateId::new`, introducing `MAX_STATE_INDEX`, `MAX_SLOT_INDEX`, `MAX_NUM_SYMBOLS`, and `MAX_TRANSITION_BASE`, and computing `transition_base` using `Int64` with checked conversion back to `Int` to avoid overflow before packing.
- Added overflow checks when growing the DFA tables in `Regex::stablize_state` by bounding `new_states_len` and validating `new_states_len * num_symbols` using `Int64` before converting to `Int` and allocating the transition table.
- Modified files: `string/internal/regex_engine/state_id.mbt` and `string/internal/regex_engine/states.mbt`, with no intended public API changes for valid-size regexes.

### Testing
- Attempted to run `moon info && moon fmt && moon test && moon check`, but the `moon` tool is not installed in this environment so automated test execution failed with `moon: command not found`.
- Static/inspection validation was performed on the modified functions to ensure guards cover the previously unchecked multiplication and table-size computations, and no automated tests were executed here due to the missing tooling.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69df120e67548325950f1d4a1882749d)